### PR TITLE
Add TPU support using torch xla

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -89,8 +89,8 @@ elif (major_torch == 2) and (minor_torch < 2):
 pass
 
 # First check if CUDA is available ie a NVIDIA GPU is seen
-if not torch.cuda.is_available():
-    raise NotImplementedError("Unsloth: No NVIDIA GPU found? Unsloth currently only supports GPUs!")
+if not torch.cuda.is_available() and not torch_xla.core.xla_model.is_tpu_available():
+    raise NotImplementedError("Unsloth: No NVIDIA GPU or TPU found? Unsloth currently only supports GPUs and TPUs!")
 
 # Fix Xformers performance issues since 0.0.25
 import importlib.util


### PR DESCRIPTION
Add TPU support using torch xla in `unsloth/__init__.py`.

* Modify the existing check for CUDA availability to include TPU availability using `torch_xla.core.xla_model.is_tpu_available()`.
* Update the error message to indicate that Unsloth currently supports both GPUs and TPUs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OEvortex/unsloth-fork/pull/1?shareId=9b54e099-3008-4b81-b260-804033f981e0).